### PR TITLE
Add XeLaTeX configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ WorkDir/
 Output/
 Test/
 *.pyc
+Scripts/xelatex_config.py

--- a/README.md
+++ b/README.md
@@ -1,5 +1,28 @@
-Still very much a work-in-progress.
+**Note:** Still very much a work-in-progress.
 
-Prerequisites are the Python packages in `Script/requirements.txt` and `xelatex` in your path.
+# Prerequisites
+You should have the following:
 
-Example usage: `python ./Scripts/output_tex.py "./Volumes/Volume 3" "./Output"`
+1. Python packages listed in `Scripts/requirements.txt`
+2. `xelatex` in  your PATH
+
+Additionally, you can set up a configuration file for `xelatex`. Create `Scripts/xelatex_config.py` and populate `xelatex_extra_args`, `xelatex_output_directory`, and `xelatex_job_name`.
+
+`xelatex_extra_args` allows you to specify any extra arguments to `xelatex`. The other two specify the options for the output directory and job name, which is useful for different version of `xelatex`.
+
+**The default values are listed below as an example configuration.**
+
+```python
+xelatex_extra_args = ["-interaction=batchmode", "-enable-installer"]
+xelatex_output_directory = "-output-directory"
+xelatex_job_name = "-job-name"
+```
+
+**Note:** Currently, you have to set all three of the variables or the default will be used. (Exception being that you can set `xelatex_extra_args` as an empty list.)
+
+# Usage
+Once you have completed all the prerequisites, you can run `Scripts/output_tex.py`:
+
+```sh
+python ./Scripts/output_tex.py "./Volumes/Volume 3" "./Output"
+```

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -7,6 +7,16 @@ import subprocess
 import time
 from pathlib import Path, PurePosixPath
 
+try:
+    from xelatex_config import xelatex_extra_args, xelatex_output_directory, xelatex_job_name
+except ImportError:
+    print("XeLaTeX configuration is incomplete or does not exist. Using default values instead.")
+
+    # Provide default values if the config file doesn't exist
+    xelatex_extra_args = ["-interaction=batchmode", "-enable-installer"]
+    xelatex_output_directory = "-output-directory"
+    xelatex_job_name = "-job-name"
+
 import cv2
 import numpy as np
 from Lib.config import (Book, Chapter, ImageInfo, ImagesConfig, Part,
@@ -29,7 +39,10 @@ def format_text(text: str) -> str:
     text = text.replace(r"</i>", r"}")
     text = text.replace(r"<em>", r"\textit{")
     text = text.replace(r"</em>", r"}")
-    
+
+    text = text.replace(r"<u>", r"\underline{")
+    text = text.replace(r"</u>", r"}")
+
     text = text.replace(r"<b>", r"\textbf{")
     text = text.replace(r"</b>", r"}")    
     text = text.replace(r"<strong>", r"\textbf{")
@@ -132,11 +145,13 @@ def convert_book(book_config: Book, image_config: ImagesConfig, output_dir: Path
     tex_inputs = env_path_prepend(os.environ.get("TEXINPUTS"), work_dir, ".")
     
     args = [
-        "xelatex", "-interaction=batchmode", "-enable-installer",
-        f"-output-directory={str(intermediate_output_directory)}",
-        f"-job-name={output_stem}",
+        "xelatex",
+        *xelatex_extra_args,
+        f"{xelatex_output_directory}={str(intermediate_output_directory)}",
+        f"{xelatex_job_name}={output_stem}",
         f"{main_tex_file}"
     ]
+
     env = os.environ.copy()
     env["TEXINPUTS"] = tex_inputs
     print("==Starting xelatex==")


### PR DESCRIPTION
This PR adds an optional way to configure `xelatex` arguments in `Scripts/xelatex_config.py`.

**The default values are listed below as an example configuration.**

```python
xelatex_extra_args = ["-interaction=batchmode", "-enable-installer"]
xelatex_output_directory = "-output-directory"
xelatex_job_name = "-job-name"
```

`xelatex_extra_args` allows you to specify any extra arguments to XeLaTeX. The other two specify the options for the output directory and job name.

If the configuration file doesn't exist, it will use the defaults.

The configuration file is useful for if you want to change the arguments, which is especially useful for different versions of XeLaTeX that have different names for the arguments. For example, `-job-name` vs. `-jobname`.