### PR TITLE
Add verbose flag with colored output

### DIFF
--- a/Scripts/requirements.txt
+++ b/Scripts/requirements.txt
@@ -4,3 +4,4 @@ numpy
 opencv-python
 argparse-color-formatter
 ansicolors
+colorlog


### PR DESCRIPTION
Adds `-v` or `--verbose` for verbosity, which adds the printing for the images and uses the `nonstopmode` for xelatex instead of `batchmode`.