### PR TITLE
Add cover and titlepage to images YAML

### DIFF
--- a/Scripts/Lib/config.py
+++ b/Scripts/Lib/config.py
@@ -149,6 +149,10 @@ class ImagesConfig(DebugPrintable):
                 image = SingleImage()
             case "double":
                 image = DoubleImage()
+            case "cover":
+                image = CoverImage()
+            case "titlepage":
+                image = TitlePageImage()
             case "toc":
                 image = TOCImage()
             case _:
@@ -158,7 +162,7 @@ class ImagesConfig(DebugPrintable):
         image._subdir = subdirectory
         image.parse_yaml(node)
         return image
-    
+
     def all_images_iter(self) -> Iterator["ImageInfo"]:
         return itertools.chain(self.insert_images.values(), self.chapter_images.values())
 
@@ -281,6 +285,12 @@ class SingleImage(ImageInfo):
     def canvas_size_px(self, bleed: bool) -> tuple[int, int]:
         return _canvas_size_px_helper(bleed, False, self.px_per_in,
                                       self.width_px, self.height_px)
+
+class TitlePageImage(SingleImage):
+    pass
+
+class CoverImage(SingleImage):
+    pass
 
 class DoubleImage(ImageInfo):
     overlap_px: int

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -167,8 +167,10 @@ def image_latex_command(img_info: ImageInfo) -> str:
         image_path_string = str(PurePosixPath(img_info.relative_image_path().with_suffix(".png")))
         if (img_info.image_type == "double" or img_info.image_type == "toc"):
             return rf"\insertDoubleImage{in_curlies(image_path_string)}"
-        elif (img_info.image_type == "single"):
+        elif (img_info.image_type == "single" or img_info.image_type == "titlepage"):
             return rf"\insertSingleImage{in_curlies(image_path_string)}"
+        elif img_info.image_type == "cover":
+            return ""
         else:
             raise AssertionError(img_info.image_type)
 

--- a/Volumes/Volume 1/Images/config.yaml
+++ b/Volumes/Volume 1/Images/config.yaml
@@ -1,4 +1,6 @@
 insert:
+  cover.jpg:
+    image_type: cover
   insert1.jpg:
     image_type: single
   insert2.jpg:
@@ -10,7 +12,7 @@ insert:
   insert5.jpg:
     image_type: single
   titlepage.jpg:
-    image_type: single
+    image_type: titlepage
   toc.jpg:
     image_type: toc
 


### PR DESCRIPTION
This adds a cover and titlepage for image_type in the YAML file. For now, it is not useful, but I am hoping to generate the EPUBs with the markdown files as well.