### PR TITLE
Fix starting page number in TOC

### DIFF
--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -282,7 +282,7 @@ def get_page_numbers(file_path: Path):
     return page_numbers
 
 def draw_page_numbers(page_numbers: list[int], toc_path: Path, output_path: Path):
-    padded_numbers = [str(num).zfill(3) for num in page_numbers]
+    padded_numbers = [str(num - 3).zfill(3) for num in page_numbers]
 
     image = Image.open(toc_path)
 


### PR DESCRIPTION
I'm not sure if this is true in all of the volumes, but for volume 1 at least, the page numbers start at the image, not the first page of the chapter. So this subtracts 3 from the chapter numbers, since I'm assuming that all the chapter images are going to be 2 pages and then 1 blank page.