### PR TITLE
Change behavior with TEXINPUTS environmental variable

### DIFF
--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -60,6 +60,8 @@ def env_path_prepend(s_old: str, *args) -> str:
     l = list(args)
     if s_old and not s_old.isspace():
         l.append(s_old)
+    else:
+        l.append("") # In case TEXINPUTS is unset, retain the last `:`
     return os.pathsep.join(str(x) for x in l)
 
 def get_latex_converter() -> UnicodeToLatexEncoder:


### PR DESCRIPTION
If the `TEXINPUTS` environment variable is unset, the previous behavior was that it was not added to the `TEXINPUTS` in the xelatex command. However, this would cause problems because it removes the default directories that are supposed to be included, which is why a trailing colon should be at the end.