### PR TITLE
Print Mode

### DIFF
--- a/Common/TeX/WorldEnd2_Common.tex
+++ b/Common/TeX/WorldEnd2_Common.tex
@@ -19,11 +19,12 @@
 \documentclass[twoside]{book}
 
 \providecommand{\bleedSize}{0.0in}
+\providecommand{\gutterSize}{0.0in}
 
 \usepackage[
   paperwidth=\dimexpr5.5in + \bleedSize + \bleedSize\relax,
   paperheight=\dimexpr8.25in + \bleedSize + \bleedSize\relax,
-  inner=\dimexpr0.6in + \bleedSize\relax,
+  inner=\dimexpr0.45in + \gutterSize + \bleedSize\relax,
   outer=\dimexpr0.45in + \bleedSize\relax,
   bottom=\dimexpr0.5in + \bleedSize\relax,
   top=0in, % total is 0.95 in for top

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you want to generate the PDF for printing in a perfect-bound book, there are 
  
 By default, the bleed size is 0, gutter size is 0, and cover is included.
 
-For convenience, `-p` (`--print-mode`) is provided, which is short for `-b 0.125 -g 0.15 -n`.
+For convenience, `-p` (`--print-mode`) is provided, which is short for `-b 0.125in -g 0.15in -n`.
 
 It is possible to tweak the print options alongside `--print-mode` by appending them after. For example, `-p -b 0` enables print mode without bleed. If you put the print options before print mode, they will be overwritten, but other arguments can be put before without consequence.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ python ./Scripts/output_tex.py "./Volumes/Volume 3/" "./Output/"
 - The first argument (`"./Volumes/Volume 3/"`) specifies the path to the directory containing the volume.
 - The second argument (`"./Output/"`) is the location for the output file and any temporary working files.
 
+### Printing
+If you want to generate the PDF for printing in a perfect-bound book, there are three related flags:
+
+- `-b` (`--bleed-size`): Specify the bleed size.
+- `-g` (`--gutter-size`): Specify the gutter size.
+- `-n` (`--no-cover`): Do not include cover.
+ 
+By default, the bleed size is 0, gutter size is 0, and cover is included.
+
+For convenience, `-p` (`--print-mode`) is provided, which is short for `-b 0.125 -g 0.15 -n`.
+
+It is possible to tweak the print options alongside `--print-mode` by appending them after. For example, `-p -b 0` enables print mode without bleed. If you put the print options before print mode, they will be overwritten, but other arguments can be put before without consequence.
+
 ## Exporting to EPUB
 To export to EPUB, run `Scripts/output_epub.py`:
 

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -185,29 +185,47 @@ def convert_chapter(chapter: Chapter, work_dir: Path, content_lines: list[str]):
     for part in itertools.islice(chapter.parts, 1, None):
         convert_part(part, work_dir, content_lines)
 
-def image_latex_command(img_info: ImageInfo) -> str:
-        image_path_string = str(PurePosixPath(img_info.relative_image_path().with_suffix(".png")))
-        if (img_info.image_type == "double" or img_info.image_type == "toc"):
-            return rf"\insertDoubleImage{in_curlies(image_path_string)}"
-        elif (
-            img_info.image_type == "single"
-            or img_info.image_type == "titlepage"
-            or img_info.image_type == "filler"
-        ):
-            return rf"\insertSingleImage{in_curlies(image_path_string)}"
-        elif img_info.image_type == "cover":
-            return ""
-        else:
-            raise AssertionError(img_info.image_type)
+def image_latex_command(img_info: ImageInfo, no_cover: bool) -> str:
+    image_path_string = str(PurePosixPath(img_info.relative_image_path().with_suffix(".png")))
+    if (img_info.image_type == "double" or img_info.image_type == "toc"):
+        return rf"\insertDoubleImage{in_curlies(image_path_string)}"
+    elif (
+        img_info.image_type == "single"
+        or img_info.image_type == "titlepage"
+        or img_info.image_type == "filler"
+    ):
+        return rf"\insertSingleImage{in_curlies(image_path_string)}"
+    elif img_info.image_type == "cover":
+        return (
+            ""
+            if no_cover
+            else (
+                rf"\insertSingleImage{in_curlies(image_path_string)}" + "\n\n"
+                r"\newpage\vspace*{\fill}\thispagestyle{empty}\vspace*{\fill}\newpage"
+            )
+        )
+    else:
+        raise AssertionError(img_info.image_type)
 
-def convert_book(book_config: Book, image_config: ImagesConfig, output_dir: Path, work_dir: Path, bleed=False, dont_print_images=False, skip_generate_images=False, xelatex_command_line: str = xelatex_default_texlive):
+def convert_book(
+    book_config: Book,
+    image_config: ImagesConfig,
+    output_dir: Path,
+    work_dir: Path,
+    bleed_size=0.0,
+    dont_print_images=False,
+    skip_generate_images=False,
+    xelatex_command_line: str = xelatex_default_texlive,
+    no_cover=False,
+    gutter_size=0.0,
+):
     content_lines = []
     for img_info in image_config.insert_images.values():
-        content_lines.append(image_latex_command(img_info))
+        content_lines.append(image_latex_command(img_info, no_cover))
 
     for chapter in book_config.chapters:
         img_info = image_config.chapter_images[str(chapter.number)]
-        content_lines.append(image_latex_command(img_info))
+        content_lines.append(image_latex_command(img_info, no_cover))
         convert_chapter(chapter, work_dir, content_lines)
 
     content_text = "\n\n".join(content_lines)
@@ -216,8 +234,8 @@ def convert_book(book_config: Book, image_config: ImagesConfig, output_dir: Path
 
     config_lines = []
     config_lines.append(r"\newcommand{\volumeNumberHeaderText}{Vol." + str(book_config.volume) + "}")
-    if bleed:
-        config_lines.append(r"\newcommand{\bleedSize}{0.125in}")
+    config_lines.append(rf"\newcommand{{\bleedSize}}{in_curlies((str(bleed_size) + "in"))}")
+    config_lines.append(rf"\newcommand{{\gutterSize}}{in_curlies(str(gutter_size) + "in")}")
     if dont_print_images:
         config_lines.append(r"\providecommand{\dontPrintImages}{}")
 
@@ -261,7 +279,7 @@ def convert_book(book_config: Book, image_config: ImagesConfig, output_dir: Path
 
     if not skip_generate_images:
         page_numbers = get_page_numbers(page_numbers_file)
-        generate_images(image_config, work_dir, page_numbers, bleed)
+        generate_images(image_config, work_dir, page_numbers, bleed_size)
 
     if not dont_print_images:
         logger.info("==Starting xelatex (second pass)==")
@@ -325,7 +343,7 @@ def draw_page_numbers(page_numbers: list[int], toc_path: Path, output_path: Path
 
     image.close()
 
-def generate_images(config: ImagesConfig, work_dir: Path, page_numbers: list[int], bleed: bool):
+def generate_images(config: ImagesConfig, work_dir: Path, page_numbers: list[int], bleed_size: float):
     for image_info in config.all_images_iter():
         input_path = image_info.absolute_image_path()
         output_path = (work_dir / image_info.relative_image_path()).with_suffix(".png")
@@ -338,7 +356,7 @@ def generate_images(config: ImagesConfig, work_dir: Path, page_numbers: list[int
         img = cv2.imread(str(input_path)) 
         logger.debug(np.shape(img))
         
-        l, r, t, b = image_info.padding_lrtb(bleed)
+        l, r, t, b = image_info.padding_lrtb(bleed_size)
         logger.debug((l, r, t, b))
         mask = np.ones((img.shape[0], img.shape[1]), dtype=np.uint8) * 255
         mask = crop_and_pad_mat(mask, [(t, b), (l, r)])
@@ -385,13 +403,25 @@ def main():
     parser.add_argument("output_dir")
     parser.add_argument("-h", "--help", action="help", default=argparse.SUPPRESS,
                         help="Show this help message and exit.")
-    parser.add_argument("-b", "--bleed", action="store_true", help="Add bleed to the output file, for printing.")
+    parser.add_argument("-b", "--bleed-size", default=0.0, type=float, help="Specify bleed size (in inches). Recommended size is 0.125 inches, if printing.")
+    parser.add_argument("-g", "--gutter-size", default=0.0, type=float, help="Specify gutter size (in inches). Recommended size is 0.15 inches, if printing.")
+    parser.add_argument("-n", "--no-cover", action="store_true", help="Do not include cover in output file.")
     parser.add_argument("-v", "--verbose", action="store_true", help="Be verbose.")
     parser.add_argument("-s", "--skip-images", action="store_true", help="Skip generating the images. Will use previously generated images. Speeds up execution.")
     parser.add_argument("-d", "--dont-print-images", action="store_true", help="Don't print the images to the PDF. Greatly speeds up execution.")
     parser.add_argument("-x", "--xelatex-command-line",
                         type=str,
                         help=f"Allow overriding the command used to call xelatex. This will be formatted with `{colors.faint('str.format')}`, with keyword arguments MODE (optional to preserve verbosity), OUTPUT_DIRECTORY, JOB_NAME, and TEX_FILE. The default is `{colors.faint(xelatex_default_miktex)}` for MiKTeX, and `{colors.faint(xelatex_default_texlive)}` for TeX Live and other TeX distributions.")
+
+    # Custom action for `--print-mode`
+    class PrintMode(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            setattr(namespace, 'bleed_size', 0.125)
+            setattr(namespace, 'gutter_size', 0.15)
+            setattr(namespace, 'no_cover', True)
+
+    parser.add_argument("-p", "--print-mode", action=PrintMode, nargs=0,
+                        help=f"Activate print mode, short for `{colors.faint("-b 0.125 -g 0.15 -n")}`")
     
     args = parser.parse_args()
 
@@ -415,7 +445,7 @@ def main():
     
     images_config = parse_image_config(book_config.directory / "Images")
 
-    result = convert_book(book_config, images_config, output_dir, work_dir, args.bleed, args.dont_print_images, args.skip_images, xelatex_command)
+    result = convert_book(book_config, images_config, output_dir, work_dir, args.bleed_size, args.dont_print_images, args.skip_images, xelatex_command, args.no_cover, args.gutter_size)
 
 if __name__ == '__main__':
     main()

--- a/Scripts/requirements.txt
+++ b/Scripts/requirements.txt
@@ -7,3 +7,4 @@ ansicolors
 colorlog
 pylatexenc
 regex
+pint


### PR DESCRIPTION
This gives four flags: `--bleed-size`, `--gutter-size`, `--no-cover`, and `--print-mode`. This changes the default to have no bleed, no gutter, and includes a cover. Then print mode can be activated with `-p` or `--print-mode`, which adds the bleed and gutter and removes the cover.

You can still change the options even with `-p`; they just need to come after. So for print mode with no bleed, it would be `-p -b 0`.

The idea is that the `-b` option originally was to add the bleed for printing. But if that means that if it is not set, then we are not printing, meaning that we don't need the gutters. If you think the old behavior is better, I can change the default to print mode, with or without bleed, but I still think the gutter and bleed size are useful options.