### PR TITLE
Change image height control

### DIFF
--- a/Scripts/Lib/config.py
+++ b/Scripts/Lib/config.py
@@ -1,5 +1,6 @@
 import itertools
 import math
+import pint
 import re
 from abc import ABC, abstractmethod
 from collections import OrderedDict
@@ -19,6 +20,7 @@ from PIL import Image
 
 from .debug_printable import DebugPrintable
 
+ureg = pint.UnitRegistry()
 
 class Book(DebugPrintable):
     chapters: "list[Chapter]"
@@ -130,8 +132,8 @@ class ImagesConfig(DebugPrintable):
         with open(config_file, "r") as f:
             data = yaml.safe_load(f)
         config = ImagesConfig()
-        config.parse_yaml(data)
         config.directory = config_file.parent.resolve()
+        config.parse_yaml(data)
         return config
 
     def parse_yaml(self, node: dict):
@@ -188,41 +190,19 @@ class ImageInfo(ABC, DebugPrintable):
     vI: int = 1
 
     def length_to_inches(self, length: str) -> float:
-        m = re.match(r"^(\d+(?:\.\d+)?((?:in)|(?:cm)|(?:px)))$", length)
-        if m is None:
-            raise ValueError(f"Could not match `{length}` as a length")
-        value = float(m[1])
-        match m[2]:
-            case "in":
-                return value
-            case "cm":
-                return value / 2.54 # cm per in
-            case "px":
-                if (int(value) - value) != 0:
-                    raise ValueError(f"Non whole-number of pixels `{value}`")
-                return value / self.px_per_in
+        quantity = ureg(length)
+        converted_quantity = quantity.to("inch")
+        return converted_quantity.magnitude
 
     def length_to_px(self, length: str) -> int:
-        m = re.match(r"^(\d+(?:\.\d+)?((?:in)|(?:cm)|(?:px)))$", length)
-        if m is None:
-            raise ValueError(f"Could not match `{length}` as a length")
-        value = float(m[1])
-        match m[2]:
-            case "in":
-                return round(value * self.px_per_in)
-            case "cm":
-                return round(value * self.px_per_in / 2.54)
-            case "px":
-                if (int(value) - value) != 0:
-                    raise ValueError(f"Non whole-number of pixels `{value}`")
-                return int(value)
-    
+        return round(self.length_to_inches(length) * self.px_per_in)
+
     def parse_yaml(self, node: dict):
         self.image_type = node["image_type"]
         
         self.height_inches = PAPER_H_IN
-        if "height_inches" in node:
-            self.height_inches = self.length_to_inches(node["height_inches"])
+        if "height" in node:
+            self.height_inches = self.length_to_inches(node["height"])
 
         self.offset_px = (0, 0)
         if "offset" in node:


### PR DESCRIPTION
This one one is a draft because I'm not sure what the correct behavior is. So first of all, the config option should be renamed from `height_inches` to `height` because it does the `length_to_inches`.

I also tried to convert it to use pint for the unit conversion, but I ran into some interesting things.

The `length_to_inches` function and the px one have slight errors in the regex that make them not work, but that is easy to fix. But what I want to talk about is converting to px. I'm not sure I understand. From my understanding, when you specify the height in px, it needs the ppi to convert to inch. And the ppi is calculated by the image height divided by the page height. But isn't that assuming that the image takes up the whole height of the page, which renders the height config useless?

Additionally, trying to use `px_per_in` gives this error:

```
AttributeError: 'ImagesConfig' object has no attribute 'directory'
```

I didn't try to fix that since I wasn't sure what the behavior was supposed to be.

So this change uses the px conversion from pint, which is `inch / 96`.