### PR TITLE
Add bookmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ WorkDir/
 *.synctex.*
 *.page-numbers.txt
 *.log
+*.out
 *.fdb_latexmk
 *.fls
 *.xdv

--- a/Common/TeX/WorldEnd2_Common.tex
+++ b/Common/TeX/WorldEnd2_Common.tex
@@ -48,6 +48,14 @@
 ]{hyperref}
 
 
+\newcommand{\addPdfBookmarkForChapter}[1]{
+  \pdfbookmark[1]{#1}{chap:\theChapterNum}
+}
+
+\newcommand{\addPdfBookmarkForPart}[1]{
+  \pdfbookmark[2]{#1}{part:\theChapterNum.\thePartNum}
+}
+
 % ======= Fonts =======
 \usepackage[no-math]{fontspec}
 
@@ -107,6 +115,20 @@
  { \par\noindent\ignorespacesafterend }
 
 
+% \ifEmptyElse{condition}{value if empty}{value if nonempty}
+\newcommand{\ifEmptyElse}[3]{
+  \def\tempparam{#1}\ifx\tempparam\empty #2 \else #3 \fi
+}
+
+\newcommand{\atTopOfPage}[1]{
+  \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
+    \node[anchor=north,yshift=0pt,xshift=0pt] at (current page.north) {%
+      #1
+    };
+  \end{tikzpicture}%
+}
+
+
 % ======= Header =======
 \usepackage{fancyhdr}
 \setlength{\footskip}{5pt}
@@ -154,38 +176,6 @@
 \newcommand{\EllipsisSplittable}{\Ellipsis \penalty50}
 
 
-
-% ======= Image Commands =======
-
-\newcommand{\tikzPicture}[3]{%
-  \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
-    \node[anchor=#1,yshift=0pt,xshift=0pt] at (current page.#1) {%
-      \ifx\dontPrintImages\undefined
-        \includegraphics[height=#2]{#3}%
-      \else
-        \phantom{\includegraphics[height=#2]{#3}}%
-      \fi
-    };
-  \end{tikzpicture}%
-}
-
-\newcommand{\fullPageImage}[1]{%
-  \tikzPicture{\ifodd\value{realpage}north east\else north west\fi}{\paperheight}{#1}
-}
-
-\newcommand{\insertSingleImage}[1]{
-  \newpage\thispagestyle{empty}%
-  \fullPageImage{#1}
-}
-
-% \insertDoubleImage[command between pages]{image filename}
-\newcommand{\insertDoubleImage}[2][\empty]{
-  \newleftpage\thispagestyle{empty}\fullPageImage{#2}
-  {#1}
-  \newrightpage\thispagestyle{empty}\fullPageImage{#2}
-}
-
-
 % ======= Content Commands =======
 \newcommand{\icon}{
   % The icon takes up 3 lines
@@ -201,30 +191,9 @@
 
 \newcommand{\sectionTitleStyle}{\athiti\fontsize{11}{11}\fontseries{sb}\selectfont}
 
-% These conuted chapter numbers are mainly used for bookmarks 
+% These counted chapter numbers are mainly used for bookmarks 
 \newcounter{ChapterNum}
 \newcounter{PartNum}
-
-% \ifEmptyElse{condition}{value if empty}{value if nonempty}
-\newcommand{\ifEmptyElse}[3]{
-  \def\tempparam{#1}\ifx\tempparam\empty #2 \else #3 \fi
-}
-
-\newcommand{\atTopOfPage}[1]{
-  \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
-    \node[anchor=north,yshift=0pt,xshift=0pt] at (current page.north) {%
-      #1
-    };
-  \end{tikzpicture}%
-}
-
-\newcommand{\addPdfBookmarkForChapter}[1]{
-  \pdfbookmark[1]{#1}{chap:\theChapterNum}
-}
-
-\newcommand{\addPdfBookmarkForPart}[1]{
-  \pdfbookmark[2]{#1}{part:\theChapterNum.\thePartNum}
-}
 
 % \beginChapter[part 1 name]{chapter title}{chapter subtitle}{image command}
 \newcommand{\beginChapter}[4][\empty]{
@@ -267,6 +236,40 @@
   % The second page of the TOC is counted as "page 1"
   \setcounter{page}{1}\pagenumbering{arabic}
 }
+
+
+% ======= Image Commands =======
+
+\newcommand{\tikzPicture}[3]{%
+  \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
+    \node[anchor=#1,yshift=0pt,xshift=0pt] at (current page.#1) {%
+      \ifx\dontPrintImages\undefined
+        \includegraphics[height=#2]{#3}%
+      \else
+        \phantom{\includegraphics[height=#2]{#3}}%
+      \fi
+    };
+  \end{tikzpicture}%
+}
+
+\newcommand{\fullPageImage}[1]{%
+  \tikzPicture{\ifodd\value{realpage}north east\else north west\fi}{\paperheight}{#1}
+}
+
+\newcommand{\insertSingleImage}[1]{
+  \newpage\thispagestyle{empty}%
+  \fullPageImage{#1}
+}
+
+% \insertDoubleImage[command between pages]{image filename}
+\newcommand{\insertDoubleImage}[2][\empty]{
+  \newleftpage\thispagestyle{empty}\fullPageImage{#2}
+  {#1}
+  \newrightpage\thispagestyle{empty}\fullPageImage{#2}
+}
+
+
+% ======= Credits page =======
 
 % \creditsPage{backgroundImage}{copyrightYear}{formattedIsbn}{versionTag}
 \newcommand{\creditsPage}[4]{
@@ -326,6 +329,7 @@
   \endgroup
 }
 
+% ======= Document =======
 
 \begin{document}
 

--- a/Common/TeX/WorldEnd2_Common.tex
+++ b/Common/TeX/WorldEnd2_Common.tex
@@ -39,6 +39,15 @@
 \linespread{1.25}
 
 
+% ======= Bookmarks =======
+\usepackage[
+  unicode,
+  hidelinks,
+  bookmarksopen,
+  bookmarksnumbered
+]{hyperref}
+
+
 % ======= Fonts =======
 \usepackage[no-math]{fontspec}
 
@@ -165,6 +174,17 @@
   \pagestyle{fancy}
   \startAtPageNumber{5}
   \thispagestyle{empty} %The blank space when starting a new chapter is 9 lines. The section title (if it exists) is around the middle, a bit below line 5
+  \def\temppartname{#1}%
+  \def\defaultname{\phantom{No header}}%
+  \ifx\temppartname\defaultname
+    % empty
+  \else
+    \ifx\temppartname\empty
+      % empty
+    \else
+      \pdfbookmark[2]{#1}{part:#1}%
+    \fi
+  \fi
   \vphantom{1}\par\vphantom{2}\par\vphantom{3}\par\vphantom{4}\par
   \noindent\vphantom{5}\begin{picture}(0, 0)\put(0, -0.3\baselineskip){\sectionTitleStyle #1}\end{picture}\par
   \vphantom{6}\par\vphantom{7}\par\vphantom{8}\par\vphantom{9}
@@ -175,6 +195,7 @@
   % The blank space when starting a new section is 3 lines. The section title is around the middle, a bit below line 2
   \vphantom{1}
   
+  \pdfbookmark[2]{#1}{part:#1}
   \noindent\vphantom{2}\begin{picture}(0, 0)\put(0, -0.09\baselineskip){\sectionTitleStyle #1}\end{picture}
   
   \vphantom{3}

--- a/Common/TeX/WorldEnd2_Common.tex
+++ b/Common/TeX/WorldEnd2_Common.tex
@@ -95,8 +95,8 @@
 \newcommand{\textof}[2][sb]{{\fontseries{#1}\selectfont #2}}
 
 \newcommand*\emptypage{\newpage\hbox{}\thispagestyle{empty}\newpage}
-\newcommand*\newleftpage{\newpage\ifodd\value{page}\emptypage\fi}
-\newcommand*\newrightpage{\newpage\ifodd\value{page}\else\emptypage\fi}
+\newcommand*\newleftpage{\newpage\ifodd\value{realpage}\emptypage\fi}
+\newcommand*\newrightpage{\newpage\ifodd\value{realpage}\else\emptypage\fi}
 
 \newenvironment*{SpanEnv}
   { \providecommand{\SpanEnvClose}{} } % begin command
@@ -120,15 +120,16 @@
 
 
 % ======= Page Number =======
-\setcounter{page}{-9999}
+\pagenumbering{roman}
 
-% Reset the page number to arg1 if this is the first time we have called this command
-\newcommand{\startAtPageNumber}[1]{
-  \ifnum0>\thepage\relax
-    \setcounter{page}{#1}
-  \fi
+\usepackage{xassoccnt}
+
+% We need this "realpage" counter so that newleftpage and newrightpage work as expected
+\newcounter{realpage}
+\DeclareAssociatedCounters{page}{realpage}
+\AtBeginDocument{%
+  \stepcounter{realpage}
 }
-
 
 % ======= Typography =======
 \setlength{\lefthyphenmin}{2}
@@ -153,56 +154,6 @@
 \newcommand{\EllipsisSplittable}{\Ellipsis \penalty50}
 
 
-% ======= Content Commands =======
-\newcommand{\icon}{
-  % The icon takes up 3 lines
-  % We use `realcenter` since `center` adds vertical space
-  \begin{realcenter}
-    \vphantom{1}
-
-    \vphantom{2}\raisebox{-0.07in}[0em][0em]{\includegraphics[height=0.22in]{Images/ornament.png}}\vphantom{2}
-
-    \vphantom{3}
-  \end{realcenter}
-}
-
-\newcommand{\sectionTitleStyle}{\athiti\fontsize{11}{11}\fontseries{sb}\selectfont}
-
-\newcommand{\beginChapter}[3][{\phantom{No header}}]{
-  \newrightpage
-  \setChapterTitleInHeader{#2}{#3}
-  \pagestyle{fancy}
-  \startAtPageNumber{5}
-  \thispagestyle{empty} %The blank space when starting a new chapter is 9 lines. The section title (if it exists) is around the middle, a bit below line 5
-  \def\temppartname{#1}%
-  \def\defaultname{\phantom{No header}}%
-  \ifx\temppartname\defaultname
-    % empty
-  \else
-    \ifx\temppartname\empty
-      % empty
-    \else
-      \pdfbookmark[2]{#1}{part:#1}%
-    \fi
-  \fi
-  \vphantom{1}\par\vphantom{2}\par\vphantom{3}\par\vphantom{4}\par
-  \noindent\vphantom{5}\begin{picture}(0, 0)\put(0, -0.3\baselineskip){\sectionTitleStyle #1}\end{picture}\par
-  \vphantom{6}\par\vphantom{7}\par\vphantom{8}\par\vphantom{9}
-  \write\pageNumbersFile{ChapterPageNumber: \thepage}
-}
-
-\newcommand{\beginPart}[1]{
-  % The blank space when starting a new section is 3 lines. The section title is around the middle, a bit below line 2
-  \vphantom{1}
-  
-  \pdfbookmark[2]{#1}{part:#1}
-  \noindent\vphantom{2}\begin{picture}(0, 0)\put(0, -0.09\baselineskip){\sectionTitleStyle #1}\end{picture}
-  
-  \vphantom{3}
-}
-
-\newcommand{\insertPartText}[1]{\noindent\input{#1}}
-
 
 % ======= Image Commands =======
 
@@ -219,7 +170,7 @@
 }
 
 \newcommand{\fullPageImage}[1]{%
-  \tikzPicture{\ifodd\value{page}north east\else north west\fi}{\paperheight}{#1}
+  \tikzPicture{\ifodd\value{realpage}north east\else north west\fi}{\paperheight}{#1}
 }
 
 \newcommand{\insertSingleImage}[1]{
@@ -227,9 +178,94 @@
   \fullPageImage{#1}
 }
 
-\newcommand{\insertDoubleImage}[1]{
-  \newleftpage\thispagestyle{empty}\fullPageImage{#1}
-  \newrightpage\thispagestyle{empty}\fullPageImage{#1}
+% \insertDoubleImage[command between pages]{image filename}
+\newcommand{\insertDoubleImage}[2][\empty]{
+  \newleftpage\thispagestyle{empty}\fullPageImage{#2}
+  {#1}
+  \newrightpage\thispagestyle{empty}\fullPageImage{#2}
+}
+
+
+% ======= Content Commands =======
+\newcommand{\icon}{
+  % The icon takes up 3 lines
+  % We use `realcenter` since `center` adds vertical space
+  \begin{realcenter}
+    \vphantom{1}
+
+    \vphantom{2}\raisebox{-0.07in}[0em][0em]{\includegraphics[height=0.22in]{Images/ornament.png}}\vphantom{2}
+
+    \vphantom{3}
+  \end{realcenter}
+}
+
+\newcommand{\sectionTitleStyle}{\athiti\fontsize{11}{11}\fontseries{sb}\selectfont}
+
+% These conuted chapter numbers are mainly used for bookmarks 
+\newcounter{ChapterNum}
+\newcounter{PartNum}
+
+% \ifEmptyElse{condition}{value if empty}{value if nonempty}
+\newcommand{\ifEmptyElse}[3]{
+  \def\tempparam{#1}\ifx\tempparam\empty #2 \else #3 \fi
+}
+
+\newcommand{\atTopOfPage}[1]{
+  \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
+    \node[anchor=north,yshift=0pt,xshift=0pt] at (current page.north) {%
+      #1
+    };
+  \end{tikzpicture}%
+}
+
+\newcommand{\addPdfBookmarkForChapter}[1]{
+  \pdfbookmark[1]{#1}{chap:\theChapterNum}
+}
+
+\newcommand{\addPdfBookmarkForPart}[1]{
+  \pdfbookmark[2]{#1}{part:\theChapterNum.\thePartNum}
+}
+
+% \beginChapter[part 1 name]{chapter title}{chapter subtitle}{image command}
+\newcommand{\beginChapter}[4][\empty]{
+  % Increment the chapter number and set the part number to 1
+  \stepcounter{ChapterNum}
+  \setcounter{PartNum}{1}
+
+  % Insert the chapter image, setting the PDF bookmark for the chapter to the first page
+  % of the image
+  \insertDoubleImage[\atTopOfPage{\addPdfBookmarkForChapter{#2}}]{#4}
+
+  \newrightpage
+  \setChapterTitleInHeader{#2}{#3}
+  \pagestyle{fancy}
+  \thispagestyle{empty}
+
+  %The blank space when starting a new chapter is 9 lines. The part title (if it exists) is around the middle, a bit below line 5
+  \vphantom{1}\par\vphantom{2}\par\vphantom{3}\par\vphantom{4}\ifEmptyElse{#1}{}{\addPdfBookmarkForPart{#1}}\par
+  \noindent\vphantom{5}\begin{picture}(0, 0)\put(0, -0.3\baselineskip){\sectionTitleStyle #1}\end{picture}\par
+  \vphantom{6}\par\vphantom{7}\par\vphantom{8}\par\vphantom{9}
+  \write\pageNumbersFile{ChapterPageNumber: \thepage}
+}
+
+\newcommand{\beginPart}[1]{
+  \stepcounter{PartNum} % Increment the part number
+
+  % The blank space when starting a new section is 3 lines. The section title is around the middle, a bit below line 2
+  \vphantom{1}\addPdfBookmarkForPart{#1}
+
+  \noindent\vphantom{2}\begin{picture}(0, 0)\put(0, -0.09\baselineskip){\sectionTitleStyle #1}\end{picture}
+  
+  \vphantom{3}
+}
+
+\newcommand{\insertPartText}[1]{\noindent\input{#1}}
+
+\newcommand{\insertTableOfContents}[1]{
+  \insertDoubleImage{#1}
+
+  % The second page of the TOC is counted as "page 1"
+  \setcounter{page}{1}\pagenumbering{arabic}
 }
 
 % \creditsPage{backgroundImage}{copyrightYear}{formattedIsbn}{versionTag}

--- a/Common/TeX/WorldEnd2_Common.tex
+++ b/Common/TeX/WorldEnd2_Common.tex
@@ -115,11 +115,6 @@
  { \par\noindent\ignorespacesafterend }
 
 
-% \ifEmptyElse{condition}{value if empty}{value if nonempty}
-\newcommand{\ifEmptyElse}[3]{
-  \def\tempparam{#1}\ifx\tempparam\empty #2 \else #3 \fi
-}
-
 \newcommand{\atTopOfPage}[1]{
   \begin{tikzpicture}[remember picture,overlay,every node/.style={inner sep=0,outer sep=0}]
     \node[anchor=north,yshift=0pt,xshift=0pt] at (current page.north) {%
@@ -210,8 +205,8 @@
   \pagestyle{fancy}
   \thispagestyle{empty}
 
-  %The blank space when starting a new chapter is 9 lines. The part title (if it exists) is around the middle, a bit below line 5
-  \vphantom{1}\par\vphantom{2}\par\vphantom{3}\par\vphantom{4}\ifEmptyElse{#1}{}{\addPdfBookmarkForPart{#1}}\par
+  % The blank space when starting a new chapter is 9 lines. The part title (if it exists) is around the middle, a bit below line 5
+  \vphantom{1}\par\vphantom{2}\par\vphantom{3}\par\vphantom{4}\IfStrEq{#1}{}{}{\addPdfBookmarkForPart{#1}}\par
   \noindent\vphantom{5}\begin{picture}(0, 0)\put(0, -0.3\baselineskip){\sectionTitleStyle #1}\end{picture}\par
   \vphantom{6}\par\vphantom{7}\par\vphantom{8}\par\vphantom{9}
   \write\pageNumbersFile{ChapterPageNumber: \thepage}

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -392,11 +392,9 @@ def convert_book(
                 image_info.padding_lrtb(bleed_size),
             )
 
-    # We need the second pass even if we aren't printing images, so that the page numbers output
-    # by hyperref are correct
-    logger.info("==Starting xelatex (second pass)==")
-    env["TEXINPUTS"] = tex_inputs
-    subprocess.run(args=args, env=env, cwd=str(main_tex_file.parent))
+        logger.info("==Starting xelatex (second pass)==")
+        env["TEXINPUTS"] = tex_inputs
+        subprocess.run(args=args, env=env, cwd=str(main_tex_file.parent))
 
     logger.info("==Finished xelatex==")
     intermediate_output_file = intermediate_output_directory / (output_stem + ".pdf")

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -304,6 +304,12 @@ def convert_book(
 
     for chapter in book_config.chapters:
         img_info = image_config.chapter_images[chapter.number]
+        content_lines.append(rf"\newleftpage")
+        content_lines.append(rf"\phantomsection")
+        content_lines.append(
+            rf"\pdfbookmark[1]{{{chapter.title}}}{{chap:{chapter.number}}}"
+        )
+
         content_lines.append(image_latex_command(img_info))
         convert_chapter(chapter, work_dir, content_lines)
 

--- a/Scripts/output_tex.py
+++ b/Scripts/output_tex.py
@@ -392,9 +392,9 @@ def convert_book(
                 image_info.padding_lrtb(bleed_size),
             )
 
-        logger.info("==Starting xelatex (second pass)==")
-        env["TEXINPUTS"] = tex_inputs
-        subprocess.run(args=args, env=env, cwd=str(main_tex_file.parent))
+    logger.info("==Starting xelatex (second pass)==")
+    env["TEXINPUTS"] = tex_inputs
+    subprocess.run(args=args, env=env, cwd=str(main_tex_file.parent))
 
     logger.info("==Finished xelatex==")
     intermediate_output_file = intermediate_output_directory / (output_stem + ".pdf")


### PR DESCRIPTION
So in certain PDF viewers, there's an index, which is like a TOC. This allows you to click the items in the TOC and go to the part in the PDF. See how it looks in zathura:

<img width="915" height="498" alt="image" src="https://github.com/user-attachments/assets/17c76bef-d36c-4b82-b926-0a4595dbf72e" />

So I tried to add it here, but it doesn't quite work correctly. I have the chapter entries go to the chapter image, and the parts go to the parts. But I can't get the chapter entry to go to the top of the page of the chapter image; it goes a little bit down for me. We also should add the cover, titlepage, inserts, etc. as well.

And because I added hyperref, now it contains the logical page numbers (the page numbers showing in the PDF and not the physical page numbers). So you can see, the way we do the images as -9999 doesn't quite work well, and causes some weirdness with the page number.