### PR TITLE
Replacements Script

### DIFF
--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -258,17 +258,21 @@ def main():
     )
     parser.add_argument("input", help="Input .md file or directory of .md files")
     parser.add_argument("rules", help="YAML rules file")
-    parser.add_argument("-o", "--output", help="Output file or directory")
-    parser.add_argument("--in-place", action="store_true", help="Overwrite input files")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("-o", "--output", help="Output file or directory")
+    mode.add_argument(
+        "-i", "--in-place", action="store_true", help="Overwrite input files"
+    )
+
     parser.add_argument(
         "--manual-review",
         default="manual_review.md",
-        help="Path to markdown manual-review report",
+        help="Path to manual review report",
     )
     parser.add_argument(
         "--backup",
         action="store_true",
-        help="Create .bak backups when using --in-place",
+        help="Create backups when using `--in-place`",
     )
 
     args = parser.parse_args()
@@ -277,11 +281,8 @@ def main():
     rules_path = Path(args.rules)
     manual_review_path = Path(args.manual_review)
 
-    if not args.in_place and not args.output:
-        raise SystemExit("You must specify either --in-place or --output")
-
-    if args.in_place and args.output:
-        raise SystemExit("Use either --in-place or --output, not both")
+    if args.backup and not args.in_place:
+        parser.error("--backup can only be used with --in-place")
 
     rules = load_rules(rules_path)
     files = collect_md_files(input_path)

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -115,26 +115,23 @@ def apply_case_pattern(source: str, replacement: str) -> str:
 
 
 def is_sentence_start(text: str, start: int) -> bool:
-    prefix = text[:start]
-
-    if not prefix.strip():
+    if start == 0:
         return True
 
-    stripped = prefix.rstrip()
-    if not stripped:
+    i = start - 1
+    while i >= 0 and text[i] in (" ", "\t"):
+        i -= 1
+
+    if i < 0:
         return True
 
-    lookback = stripped[-200:]
-
-    if "\n\n" in lookback:
-        after_last_para = lookback.split("\n\n")[-1].strip()
-        if not after_last_para:
-            return True
-
-    if stripped.endswith("\n"):
+    if text[i] == "\n":
         return True
 
-    return bool(SENTENCE_END_RE.search(stripped))
+    lookback_start = max(0, i - 200)
+    lookback = text[lookback_start : i + 1].rstrip()
+
+    return bool(SENTENCE_END_RE.search(lookback))
 
 
 def make_replacement_function(rule: Rule, full_text: str):

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -205,13 +205,10 @@ def write_output_file(
 
 
 def write_manual_review(manual_hits, output_path: Path):
-    lines = ["# Manual Review Report", ""]
-
     if not manual_hits:
-        lines.append("No manual-review matches found.")
-        lines.append("")
-        output_path.write_text("\n".join(lines), encoding="utf-8")
         return
+
+    lines = ["# Manual Review Report", ""]
 
     current_file = None
     current_rule = None
@@ -313,7 +310,8 @@ def main():
     write_manual_review(all_manual_hits, manual_review_path)
 
     print(f"Processed {len(files)} file(s).")
-    print(f"Manual review file: {manual_review_path}")
+    if all_manual_hits:
+        print(f"Manual review file: {manual_review_path}")
     print(f"Manual-review hits: {len(all_manual_hits)}")
 
 

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -244,7 +244,7 @@ def write_manual_review(manual_hits, output_path: Path):
                 lines.append(f"- notes: {hit['notes']}")
             lines.append("")
 
-        lines.append(f"- line {hit['line']}, col {hit['column']}")
+        lines.append(f"- location: `{hit['file']}:{hit['line']}:{hit['column']}`")
         lines.append(f"  - matched: `{hit['match_text']}`")
         lines.append(f"  - context: `{hit['snippet']}`")
         lines.append("")

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -7,7 +7,8 @@ from typing import List, Tuple
 
 import yaml
 
-SENTENCE_END_RE = re.compile(r'[.!?…]["\')\]]*\s*$')
+SEP = r'(?:[\s"\'“”‘’)\]]|<[^<>]+>)*'
+BOUNDARY_RE = re.compile(r"(?:[.!?…]" + SEP + r"|\n\s*\n" + SEP + r")$")
 
 
 @dataclass
@@ -118,20 +119,8 @@ def is_sentence_start(text: str, start: int) -> bool:
     if start == 0:
         return True
 
-    i = start - 1
-    while i >= 0 and text[i] in (" ", "\t"):
-        i -= 1
-
-    if i < 0:
-        return True
-
-    if text[i] == "\n":
-        return True
-
-    lookback_start = max(0, i - 200)
-    lookback = text[lookback_start : i + 1].rstrip()
-
-    return bool(SENTENCE_END_RE.search(lookback))
+    lookback = text[max(0, start - 2000) : start]
+    return bool(BOUNDARY_RE.search(lookback))
 
 
 def make_replacement_function(rule: Rule, full_text: str):

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -256,8 +256,17 @@ def main():
     parser = argparse.ArgumentParser(
         description="Regex/plain-text replacement on Markdown files using YAML rules."
     )
+    default_rules_path = (
+        Path(__file__).resolve().parent.parent / "Volumes" / "replacements.yaml"
+    )
+
     parser.add_argument("input", help="Input .md file or directory of .md files")
-    parser.add_argument("rules", help="YAML rules file")
+    parser.add_argument(
+        "--rules",
+        default=default_rules_path,
+        help=f"YAML rules file (default: Volumes/replacements.yaml)",
+    )
+
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("-o", "--output", help="Output file or directory")
     mode.add_argument(

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -303,10 +303,11 @@ def main():
         )
 
         if args.in_place:
-            if args.backup:
-                backup_path = file_path.with_suffix(file_path.suffix + ".bak")
-                shutil.copy2(file_path, backup_path)
-            file_path.write_text(new_text, encoding="utf-8")
+            if new_text != original_text:
+                if args.backup:
+                    backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+                    shutil.copy2(file_path, backup_path)
+                file_path.write_text(new_text, encoding="utf-8")
         else:
             write_output_file(file_path, input_path, output_path, new_text)
 

--- a/Scripts/regex_replace.py
+++ b/Scripts/regex_replace.py
@@ -1,0 +1,324 @@
+import argparse
+import re
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Tuple
+
+import yaml
+
+SENTENCE_END_RE = re.compile(r'[.!?…]["\')\]]*\s*$')
+
+
+@dataclass
+class Rule:
+    find: str
+    replace: str
+    regex: bool = False
+    manual: bool = False
+    notes: str = ""
+    flags: int = 0
+    case_mode: str = "literal"  # literal | preserve_case | sentence_aware
+
+    def pattern(self) -> re.Pattern:
+        if self.regex:
+            return re.compile(self.find, self.flags)
+        return re.compile(re.escape(self.find), self.flags)
+
+
+def load_rules(yaml_path: Path) -> List[Rule]:
+    with yaml_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not data or "rules" not in data:
+        raise ValueError('YAML file must contain a top-level "rules" list.')
+
+    rules = []
+    for i, item in enumerate(data["rules"], start=1):
+        if not item:
+            continue
+
+        find = item.get("find")
+        replace = item.get("replace", "")
+        regex = bool(item.get("regex", False))
+        manual = bool(item.get("manual", False))
+        notes = item.get("notes", "")
+        case_mode = item.get("case_mode", "literal")
+
+        if case_mode not in {"literal", "preserve_case", "sentence_aware"}:
+            raise ValueError(f"Rule #{i}: invalid case_mode '{case_mode}'")
+
+        if find is None:
+            raise ValueError(f'Rule #{i} is missing "find".')
+
+        flags_value = 0
+        flags_list = item.get("flags", [])
+        if isinstance(flags_list, str):
+            flags_list = [flags_list]
+
+        for flag in flags_list:
+            flag = flag.lower()
+            if flag in ("i", "ignorecase"):
+                flags_value |= re.IGNORECASE
+            elif flag in ("m", "multiline"):
+                flags_value |= re.MULTILINE
+            elif flag in ("s", "dotall"):
+                flags_value |= re.DOTALL
+            else:
+                raise ValueError(f'Unknown flag "{flag}" in rule #{i}')
+
+        rules.append(
+            Rule(
+                find=find,
+                replace=replace,
+                regex=regex,
+                manual=manual,
+                notes=notes,
+                flags=flags_value,
+                case_mode=case_mode,
+            )
+        )
+
+    return rules
+
+
+def line_col_from_offset(text: str, offset: int) -> Tuple[int, int]:
+    line = text.count("\n", 0, offset) + 1
+    last_newline = text.rfind("\n", 0, offset)
+    if last_newline == -1:
+        col = offset + 1
+    else:
+        col = offset - last_newline
+    return line, col
+
+
+def capitalize_initial(s: str) -> str:
+    if not s:
+        return s
+    return s[0].upper() + s[1:]
+
+
+def apply_case_pattern(source: str, replacement: str) -> str:
+    if not source:
+        return replacement
+
+    if source.isupper():
+        return replacement.upper()
+
+    if source.islower():
+        return replacement.lower()
+
+    if source[0].isupper() and source[1:].islower():
+        return capitalize_initial(replacement.lower())
+
+    return replacement
+
+
+def is_sentence_start(text: str, start: int) -> bool:
+    prefix = text[:start]
+
+    if not prefix.strip():
+        return True
+
+    stripped = prefix.rstrip()
+    if not stripped:
+        return True
+
+    lookback = stripped[-200:]
+
+    if "\n\n" in lookback:
+        after_last_para = lookback.split("\n\n")[-1].strip()
+        if not after_last_para:
+            return True
+
+    if stripped.endswith("\n"):
+        return True
+
+    return bool(SENTENCE_END_RE.search(stripped))
+
+
+def make_replacement_function(rule: Rule, full_text: str):
+    def repl(match: re.Match) -> str:
+        expanded = match.expand(rule.replace)
+
+        if rule.case_mode == "literal":
+            return expanded
+
+        if rule.case_mode == "preserve_case":
+            return apply_case_pattern(match.group(0), expanded)
+
+        if rule.case_mode == "sentence_aware":
+            if is_sentence_start(full_text, match.start()):
+                return capitalize_initial(expanded)
+            return expanded.lower()
+
+        return expanded
+
+    return repl
+
+
+def apply_rules(text: str, rules: List[Rule], file_path: str):
+    manual_hits = []
+    replacement_counts = []
+
+    for idx, rule in enumerate(rules, start=1):
+        pattern = rule.pattern()
+        matches = list(pattern.finditer(text))
+
+        if matches and rule.manual:
+            for m in matches:
+                line, col = line_col_from_offset(text, m.start())
+                snippet_start = max(0, m.start() - 50)
+                snippet_end = min(len(text), m.end() + 50)
+                snippet = text[snippet_start:snippet_end].replace("\n", "\\n")
+                manual_hits.append(
+                    {
+                        "file": file_path,
+                        "rule_number": idx,
+                        "find": rule.find,
+                        "replace": rule.replace,
+                        "line": line,
+                        "column": col,
+                        "match_text": m.group(0),
+                        "notes": rule.notes,
+                        "snippet": snippet,
+                    }
+                )
+
+        repl_func = make_replacement_function(rule, text)
+        text, replaced_count = pattern.subn(repl_func, text)
+
+        replacement_counts.append((idx, replaced_count, rule.find, rule.replace))
+
+    return text, manual_hits, replacement_counts
+
+
+def collect_md_files(input_path: Path) -> List[Path]:
+    if input_path.is_file():
+        if input_path.suffix.lower() != ".md":
+            raise ValueError(f"Input file is not .md: {input_path}")
+        return [input_path]
+
+    if input_path.is_dir():
+        return sorted(input_path.rglob("*.md"))
+
+    raise ValueError(f"Input path does not exist: {input_path}")
+
+
+def write_output_file(
+    src_file: Path, input_base: Path, output_base: Path, content: str
+):
+    if input_base.is_file():
+        out_file = output_base
+    else:
+        rel = src_file.relative_to(input_base)
+        out_file = output_base / rel
+
+    out_file.parent.mkdir(parents=True, exist_ok=True)
+    out_file.write_text(content, encoding="utf-8")
+
+
+def write_manual_review(manual_hits, output_path: Path):
+    lines = ["# Manual Review Report", ""]
+
+    if not manual_hits:
+        lines.append("No manual-review matches found.")
+        lines.append("")
+        output_path.write_text("\n".join(lines), encoding="utf-8")
+        return
+
+    current_file = None
+    current_rule = None
+
+    for hit in manual_hits:
+        if hit["file"] != current_file:
+            current_file = hit["file"]
+            current_rule = None
+            lines.append(f"## File: `{current_file}`")
+            lines.append("")
+
+        rule_key = (hit["rule_number"], hit["find"], hit["replace"], hit["notes"])
+        if rule_key != current_rule:
+            current_rule = rule_key
+            lines.append(f"### Rule {hit['rule_number']}")
+            lines.append(f"- find: `{hit['find']}`")
+            lines.append(f"- replace: `{hit['replace']}`")
+            if hit["notes"]:
+                lines.append(f"- notes: {hit['notes']}")
+            lines.append("")
+
+        lines.append(f"- line {hit['line']}, col {hit['column']}")
+        lines.append(f"  - matched: `{hit['match_text']}`")
+        lines.append(f"  - context: `{hit['snippet']}`")
+        lines.append("")
+
+    output_path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Regex/plain-text replacement on Markdown files using YAML rules."
+    )
+    parser.add_argument("input", help="Input .md file or directory of .md files")
+    parser.add_argument("rules", help="YAML rules file")
+    parser.add_argument("-o", "--output", help="Output file or directory")
+    parser.add_argument("--in-place", action="store_true", help="Overwrite input files")
+    parser.add_argument(
+        "--manual-review",
+        default="manual_review.md",
+        help="Path to markdown manual-review report",
+    )
+    parser.add_argument(
+        "--backup",
+        action="store_true",
+        help="Create .bak backups when using --in-place",
+    )
+
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    rules_path = Path(args.rules)
+    manual_review_path = Path(args.manual_review)
+
+    if not args.in_place and not args.output:
+        raise SystemExit("You must specify either --in-place or --output")
+
+    if args.in_place and args.output:
+        raise SystemExit("Use either --in-place or --output, not both")
+
+    rules = load_rules(rules_path)
+    files = collect_md_files(input_path)
+
+    all_manual_hits = []
+    all_replacement_counts = []
+
+    output_path = Path(args.output) if args.output else None
+
+    for file_path in files:
+        original_text = file_path.read_text(encoding="utf-8")
+        new_text, manual_hits, replacement_counts = apply_rules(
+            original_text, rules, str(file_path)
+        )
+
+        all_manual_hits.extend(manual_hits)
+        all_replacement_counts.extend(
+            (str(file_path), *item) for item in replacement_counts
+        )
+
+        if args.in_place:
+            if args.backup:
+                backup_path = file_path.with_suffix(file_path.suffix + ".bak")
+                shutil.copy2(file_path, backup_path)
+            file_path.write_text(new_text, encoding="utf-8")
+        else:
+            write_output_file(file_path, input_path, output_path, new_text)
+
+    write_manual_review(all_manual_hits, manual_review_path)
+
+    print(f"Processed {len(files)} file(s).")
+    print(f"Manual review file: {manual_review_path}")
+    print(f"Manual-review hits: {len(all_manual_hits)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Volumes/Volume_04/Text/3.4.md
+++ b/Volumes/Volume_04/Text/3.4.md
@@ -10,9 +10,9 @@ It tasted icy and sweet, with a hint of sweet and sour. This new taste made Tiat
 
 She and Nopht were enjoying a snack in a café overlooking the fountain.
 
-Glick wasn’t there; he remained at headquarters, discussing some complicated matters with the First Division’s technical officer. While it seemed a little improper to let two faeries go out without their supervisor, no one had said anything so far… so it was just how it was for now.
+Glick wasn’t there; he remained at headquarters, discussing some complicated matters with the First Division’s technical officer. While it seemed a little improper to let two faeries go out without their supervisor, no one had said anything so far…so it was just how it was for now.
 
-“Ugh, seriously! This is so frustrating—I can’t stand it!”
+“Ugh, seriously! This is so frustrating— I can’t stand it!”
 
 Nopht herself was clearly in a terrible mood as she dug into the pear tart with her fork. “Why is Nygglatho considered a criminal? No matter how you think about it, it’s strange. Rather than going through the trouble of kidnapping, she’d probably just burn and eat him right then and there.”
 
@@ -30,11 +30,11 @@ After negotiating, the two decided to trade a bite of yogurt cake for a bite of 
 
 The menu beside her read “Manager’s Recommendation,” accompanied by a drawing of a donut set. It looked truly delicious. After all, this was a rare opportunity, and she was eager to try it. She debated for a long time, but ultimately chose the yogurt cake.
 
-She always felt, truly always felt, that even if she ate the donuts, something would be slightly off. It’s not that she had any grievances against her tablemate, Nopht. No, that wasn’t it… but that was just what it felt like.
+She always felt, truly always felt, that even if she ate the donuts, something would be slightly off. It’s not that she had any grievances against her tablemate, Nopht. No, that wasn’t it…but that was just what it felt like.
 
 <em>…Why am I making excuses, and who am I telling them to?</em>
 
-“I hope the real culprit can be caught soon and the misunderstanding clears up. Also, if that huge… Doctor Ma… Margo or something is safe, that’d be great.”
+“I hope the real culprit can be caught soon and the misunderstanding clears up. Also, if that huge…Doctor Ma…Margo or something is safe, that’d be great.”
 
 “That’s right. It’s really frustrating that we can’t catch him ourselves.”
 
@@ -72,7 +72,7 @@ Even if Tiat tried to get her approval, she didn’t know what to say.
 
 “Huh?”
 
-“Although we’re of different races, he’s been by your side as a partner for years. It’s a relationship of trust… so it should be pretty solid, right?”
+“Although we’re of different races, he’s been by your side as a partner for years. It’s a relationship of trust…so it should be pretty solid, right?”
 
 “Oh, no, no. I don’t think it’s the kind of relationship you’re thinking of.” Nopht shook her head. “Besides, the boggards don’t have a culture of lovers or couples. A child born to someone in the clan is raised by everybody in the clan. At that moment, all elders are parents, and all younglings are children. That’s why their surnames are the names of their clan, not their parents, see?”
 
@@ -170,7 +170,7 @@ This outfit, indeed, looked as if it was prepared for the sole purpose of killin
 
 “Ah… Okay!”
 
-Tiat cast aside her fanciful thoughts and faced reality… which was “a soft, fluffy, creamy cake with seasonal colors.”
+Tiat cast aside her fanciful thoughts and faced reality…which was “a soft, fluffy, creamy cake with seasonal colors.”
 
 Yes, now was the time to enjoy this incredibly delicious cake and forget all those unpleasant thoughts.
 

--- a/Volumes/Volume_04/Text/3.4.md
+++ b/Volumes/Volume_04/Text/3.4.md
@@ -8,19 +8,19 @@ It was hard to describe; it was like a work of art. The moment she poked the spo
 
 It tasted icy and sweet, with a hint of sweet and sour. This new taste made Tiat squirm uncontrollably.
 
-She and Noft were enjoying a snack in a café overlooking the fountain.
+She and Nopht were enjoying a snack in a café overlooking the fountain.
 
-Grick wasn’t there; he remained at headquarters, discussing some complicated matters with the First Division’s technical officer. While it seemed a little improper to let two fairies go out without their supervisor, no one had said anything so far… so it was just how it was for now.
+Glick wasn’t there; he remained at headquarters, discussing some complicated matters with the First Division’s technical officer. While it seemed a little improper to let two faeries go out without their supervisor, no one had said anything so far… so it was just how it was for now.
 
 “Ugh, seriously! This is so frustrating—I can’t stand it!”
 
-Noft herself was clearly in a terrible mood as she dug into the pear tart with her fork. “Why is Naigrat considered a criminal? No matter how you think about it, it’s strange. Rather than going through the trouble of kidnapping, she’d probably just burn and eat him right then and there.”
+Nopht herself was clearly in a terrible mood as she dug into the pear tart with her fork. “Why is Nygglatho considered a criminal? No matter how you think about it, it’s strange. Rather than going through the trouble of kidnapping, she’d probably just burn and eat him right then and there.”
 
-<em>No, that’s hard to say…</em> Tiat thought, but kept it to herself. “I’m telling you, it’s just a misunderstanding. Mr. Grick seems to be handling the matter right now. They’ll surely understand soon.”
+<em>No, that’s hard to say…</em> Tiat thought, but kept it to herself. “I’m telling you, it’s just a misunderstanding. Mr. Glick seems to be handling the matter right now. They’ll surely understand soon.”
 
 “No, no, no, you’re too naive… That person has a clingy, stubborn face. Once listed as a suspect, they’ll be suspected to the bitter end until they die. That’s <em>absolutely</em> what’s going to happen!”
 
-Noft opened her mouth wide as she settled a piece of the pear tart in her mouth before chewing on it.
+Nopht opened her mouth wide as she settled a piece of the pear tart in her mouth before chewing on it.
 
 “…This is delicious,” she declared solemnly.
 
@@ -30,7 +30,7 @@ After negotiating, the two decided to trade a bite of yogurt cake for a bite of 
 
 The menu beside her read “Manager’s Recommendation,” accompanied by a drawing of a donut set. It looked truly delicious. After all, this was a rare opportunity, and she was eager to try it. She debated for a long time, but ultimately chose the yogurt cake.
 
-She always felt, truly always felt, that even if she ate the donuts, something would be slightly off. It’s not that she had any grievances against her tablemate, Noft. No, that wasn’t it… but that was just what it felt like.
+She always felt, truly always felt, that even if she ate the donuts, something would be slightly off. It’s not that she had any grievances against her tablemate, Nopht. No, that wasn’t it… but that was just what it felt like.
 
 <em>…Why am I making excuses, and who am I telling them to?</em>
 
@@ -38,7 +38,7 @@ She always felt, truly always felt, that even if she ate the donuts, something w
 
 “That’s right. It’s really frustrating that we can’t catch him ourselves.”
 
-Noft chewed a bite and said, “This is delicious too! Give me another bite.”
+Nopht chewed a bite and said, “This is delicious too! Give me another bite.”
 
 “I can’t give you any more. The rest is all mine.” Tiat replied.
 
@@ -52,45 +52,45 @@ The plate was cleared out.
 
 “Yeah, sort of.”
 
-Noft poured milk into her teacup until it was almost filled to the brim.
+Nopht poured milk into her teacup until it was almost filled to the brim.
 
 “…I feel like I always end up thinking about what happened during that time.”
 
 “What time?”
 
-Noft slowly lifted the cup, brought the rim to her lips, and began to sip. “It’s about when Kutori was obsessed with that Second Enchanted Weapons Technician.” There was a note of nostalgia in her voice as she rested her elbows on the table, gazing out beyond the fountain plaza.
+Nopht slowly lifted the cup, brought the rim to her lips, and began to sip. “It’s about when Chtholly was obsessed with that Second Enchantments Officer.” There was a note of nostalgia in her voice as she rested her elbows on the table, gazing out beyond the fountain plaza.
 
 “I just can’t understand what it’s like to fall in love with a man. I never understood why she smiled at the end.”
 
 “…Senior?”
 
-“But it can’t be helped, right? Fairies are just like that. The so-called men and women… Those genders exist for the sole purpose of reproduction, don’t they? That has nothing to do with us, right?”
+“But it can’t be helped, right? Faeries are just like that. The so-called men and women… Those genders exist for the sole purpose of reproduction, don’t they? That has nothing to do with us, right?”
 
 Even if Tiat tried to get her approval, she didn’t know what to say.
 
-“Well, but what about Mr. Grick?”
+“Well, but what about Mr. Glick?”
 
 “Huh?”
 
 “Although we’re of different races, he’s been by your side as a partner for years. It’s a relationship of trust… so it should be pretty solid, right?”
 
-“Oh, no, no. I don’t think it’s the kind of relationship you’re thinking of.” Noft shook her head. “Besides, the Borgles don’t have a culture of lovers or couples. A child born to someone in the clan is raised by everybody in the clan. At that moment, all elders are parents, and all younglings are children. That’s why their surnames are the names of their clan, not their parents, see?”
+“Oh, no, no. I don’t think it’s the kind of relationship you’re thinking of.” Nopht shook her head. “Besides, the boggards don’t have a culture of lovers or couples. A child born to someone in the clan is raised by everybody in the clan. At that moment, all elders are parents, and all younglings are children. That’s why their surnames are the names of their clan, not their parents, see?”
 
 “Oh.”
 
-Judging from the frank expression on Noft’s face as she spoke, it didn’t seem like she was hiding any shyness.
+Judging from the frank expression on Nopht’s face as she spoke, it didn’t seem like she was hiding any shyness.
 
 “If I asked you who your favorite man in the world is, what would you say?”
 
-“Well, if that’s the question, it would definitely be that big brother of ours,” Noft replied immediately.
+“Well, if that’s the question, it would definitely be that big brother of ours,” Nopht replied immediately.
 
 “Ah, just as I thought.”
 
 <em>That kind of relationship doesn’t seem all that bad</em>, Tiat thought.
 
-However, it was a different kind of relationship than the one Kutori-senior and Willem had, which was a relationship between adults in a different sense. Tiat thought it was cool, beautiful, and something she longed for.
+However, it was a different kind of relationship than the one Chtholly-senior and Willem had, which was a relationship between adults in a different sense. Tiat thought it was cool, beautiful, and something she longed for.
 
-“It’s just that, if you ask whether it’s the same kind of the fluttery, euphoric feeling that Kutori or you have right now—it does indeed seem a little different.”
+“It’s just that, if you ask whether it’s the same kind of the fluttery, euphoric feeling that Chtholly or you have right now—it does indeed seem a little different.”
 
 “Isn’t that great? I think that’s pretty good, too.”
 
@@ -98,13 +98,13 @@ However, it was a different kind of relationship than the one Kutori-senior and 
 
 “Wait a minute.”
 
-“Hmm?” Noft blinked.
+“Hmm?” Nopht blinked.
 
 “Why do you bring that up I mean please don’t compare me to my senior, no I mean being compared to my senior is an honor in itself but this is different. Feodor and I don’t have that kind of relationship we hate each other deeply whether as a person or as a mission he’s just my enemy!”
 
-“Really?” Noft smiled mischievously.
+“Really?” Nopht smiled mischievously.
 
-Although she had fired back swiftly, Noft paid her no real attention.
+Although she had fired back swiftly, Nopht paid her no real attention.
 
 “Please don’t give me that gentle, ‘Oh, how insincere!’ smile; it’s irritating.”
 
@@ -124,29 +124,29 @@ On its platform sat at least ten imposingly armed soldiers. She also saw large g
 
 “As you expected, it’s the task force to rescue Dr. Margomedari.”
 
-Tiat turned and saw Grick Graycrack raise a hand.
+Tiat turned and saw Glick Graycrack raise a hand.
 
 “Yo!” he greeted. “It’d be ideal if this can be resolved peacefully. However, if the kidnappers were to resist, it wouldn’t be possible to suppress them without sufficient military force—hence those heavily armed soldiers.”
 
 “This…” Tiat was speechless.
 
-The kidnapper mentioned in this context, based on what was discussed earlier, must be Naigrat. She was certainly not someone that ordinary soldiers could subdue, but…
+The kidnapper mentioned in this context, based on what was discussed earlier, must be Nygglatho. She was certainly not someone that ordinary soldiers could subdue, but…
 
-“Hey, I know what you want to say. But even with a bit of enhanced armament, they won’t stand a chance against that Naigrat, right?”
+“Hey, I know what you want to say. But even with a bit of enhanced armament, they won’t stand a chance against that Nygglatho, right?”
 
 No, that’s not the case. But it’s not like Tiat can say that she didn’t think that way as well.
 
-“Actually, we’ve also speculated about a possible battle with spies from the Noble Wings Empire. Seriously, the world is starting to get turbulent…”
+“Actually, we’ve also speculated about a possible battle with spies from the Winged Empire. Seriously, the world is starting to get turbulent…”
 
-<em>The Noble Wings Empire.</em>
+<em>The Winged Empire.</em>
 
-Come to think of it, that black goat-head First Officer seemed to have mentioned it. It’s an aristocratic nation that links Floating Islands 6 through 9 together as its territory. Throughout the history of Regul Aire, this nation has repeatedly attacked neighboring islands—but it was suppressed by the Winged Guard each time.
+Come to think of it, that black goat-head First Officer seemed to have mentioned it. It’s an aristocratic nation that links Islands No. 6 through No. 9 together as its territory. Throughout the history of Regule Aire, this nation has repeatedly attacked neighboring islands—but it was suppressed by the Winged Guard each time.
 
 “Oh? So, you mean, the Empire might be looking for an opportunity to seize that huge old man? Even if it means confronting the Winged Guard?”
 
-“We can’t discount that possibility. I heard that ever since the uprising in Elpis five years ago, the Noble Wings Empire and Hydrangea Tea Country have been actively trying to keep each other in check.”
+“We can’t discount that possibility. I heard that ever since the uprising in Elpis five years ago, the Winged Empire and Hydrangea Tea Country have been actively trying to keep each other in check.”
 
-“Ah…” Noft sighed, and looked up at the sky.
+“Ah…” Nopht sighed, and looked up at the sky.
 
 “I can’t stand it. They’re all like this—they just love causing trouble for their neighbors, don’t they?”
 
@@ -156,7 +156,7 @@ Tiat ignored their conversation and instead stared blankly at the transport vehi
 
 She had seen those gunpowder rifles carried by the soldiers.
 
-In preparation for the battle against the Eleventh Beast, many weapons were transported to Floating Island 38. Some were potentially useful, while there were also weapons that were quite baffling. Mixed in with these weapons was a new type of gunpowder rifle—a portable firearm capable of inflicting the greatest devastation. It was this very weapon that the soldiers were carrying. If Tiat remembered correctly, its development name was the “Pupille Gorger.”
+In preparation for the battle against the Eleventh Beast, many weapons were transported to Island No. 38. Some were potentially useful, while there were also weapons that were quite baffling. Mixed in with these weapons was a new type of gunpowder rifle—a portable firearm capable of inflicting the greatest devastation. It was this very weapon that the soldiers were carrying. If Tiat remembered correctly, its development name was the “Pupille Gorger.”
 
 According to the manual, this gunpowder rifle had enhanced close-range penetration—even capable of piercing thin walls. Due to its high price, difficulty in management, and limited utility, the entire Winged Guard had very few of them. Yet, every soldier on the transport vehicle was armed with one of these weapons… <em>What kind of urban battle were they preparing for?</em>
 
@@ -166,7 +166,7 @@ This outfit, indeed, looked as if it was prepared for the sole purpose of killin
 
 “Ah, huh? What’s wrong?” She came to her senses.
 
-“Grick said we could order another dessert as an apology for waiting for him. What do you want?”
+“Glick said we could order another dessert as an apology for waiting for him. What do you want?”
 
 “Ah… Okay!”
 

--- a/Volumes/replacements.yaml
+++ b/Volumes/replacements.yaml
@@ -431,16 +431,25 @@ rules:
     replace: official language
     case_mode: sentence_aware
 
-  - find: Floating Island
-    replace: floating island
-    case_mode: sentence_aware
-
-  - find: Island
-    replace: island
-    case_mode: sentence_aware
+  - find: '\b[Ff]loating [Ii]sland (\d+)\b'
+    replace: 'Island No. \1'
+    regex: true
 
   - find: '\b(\d+)(st|nd|rd|th)( floating)? (i|I)sland\b'
-    replace: 'Island No. \1'
+    replace: 'Island No. \1'
+    regex: true
+
+  - find: "Floating Island"
+    replace: "floating island"
+    case_mode: sentence_aware
+
+  - find: '\bIsland\b(?! No\.)'
+    replace: "island"
+    case_mode: sentence_aware
+    regex: true
+
+  - find: '\b(\d+)(st|nd|rd|th)( floating)? (i|I)sland\b'
+    replace: 'Island No. \1'
     regex: true
 
   - find: " - "

--- a/Volumes/replacements.yaml
+++ b/Volumes/replacements.yaml
@@ -53,8 +53,9 @@ rules:
   - find: Lantolq
     replace: Rhantolk
 
-  - find: Lan
+  - find: Lan\b
     replace: Rhan
+    regex: true
 
   - find: Noft Kei Desperatio
     replace: Nopht Keh Desperatio
@@ -62,8 +63,9 @@ rules:
   - find: Noft
     replace: Nopht
 
-  - find: Shiba
+  - find: Shiba\b
     replace: Siba
+    regex: true
     notes: Of "Tiat Siba Ignareo"
 
   - find: Lakish
@@ -82,8 +84,9 @@ rules:
   - find: Naigrat
     replace: Nygglatho
 
-  - find: Nai
+  - find: Nai\b
     replace: Ny
+    regex: true
 
   - find: Leila
     replace: Lillia
@@ -91,8 +94,9 @@ rules:
   - find: Asprey
     replace: Asplay
 
-  - find: Aly
+  - find: Aly\b
     replace: Allie
+    regex: true
     notes: It's very important that this one is case-sensitive, since "aly" can appear in the middle of a lot of words.
 
   - find: Lucie

--- a/Volumes/replacements.yaml
+++ b/Volumes/replacements.yaml
@@ -1,0 +1,476 @@
+# ==============================
+#   WorldEnd Replacement Sheet
+# ==============================
+
+# Each rule supports the following:
+#   `find`        Text or regex pattern to match.
+#   `replace`     Replacement text.
+#   `regex`       True if "find" is a regex. Otherwise omitted/false for literal text.
+#   `case_mode`   One of the following:
+#                   `literal`
+#                     - Use replacement exactly as written (default).
+#                   `preserve_case`
+#                     - Copy the matched text's casing when sensible.
+#                     - Examples:
+#                         fairy --> faerie
+#                         FAIRY --> FAERIE
+#                         Fairy --> Faerie
+#                   `sentence_aware`
+#                     - Capitalize only if the match starts a sentence.
+#                     - Examples:
+#                         Beastman --> semifer
+#                         "Beastman ran" at sentence start -> "Semifer ran"
+#   `manual`      If true, still apply replacement but also log the match for review.
+#   `flags`       Optional regex flags.
+#                   Supported values:
+#                     - `ignorecase` / `i`
+#                     - `multiline`  / `m`
+#                     - `dotall`     / `s`
+#                   Examples:
+#                     flags: ignorecase
+#                     flags: [ignorecase, multiline]
+#   `notes`       Any other comments.
+#
+# Notes:
+# - `sentence_aware` should only be used when the replacement should normally be lowercase.
+# - Do not use `sentence_aware` when the replacement itself is intentionally capitalized.
+#
+# Regex notes:
+# - Backreferences like `\1` are supported in replace.
+# - Rule order matters. Put more specific/longer matches before shorter ones.
+
+rules:
+  # CHARACTER NAMES
+  - find: Kutori
+    replace: Chtholly
+
+  - find: Aiseia
+    replace: Ithea
+
+  - find: Lantolq Itsuri Historia
+    replace: Rhantolk Ytri Historia
+
+  - find: Lantolq
+    replace: Rhantolk
+
+  - find: Lan
+    replace: Rhan
+
+  - find: Noft Kei Desperatio
+    replace: Nopht Keh Desperatio
+
+  - find: Noft
+    replace: Nopht
+
+  - find: Shiba
+    replace: Siba
+    notes: Of "Tiat Siba Ignareo"
+
+  - find: Lakish
+    replace: Lakhesh
+
+  - find: Panival
+    replace: Pannibal
+
+  - find: Riel
+    replace: Ryehl
+
+  - find: Grick
+    replace: Glick
+    notes: One of the two official transliterations I don't like.
+
+  - find: Naigrat
+    replace: Nygglatho
+
+  - find: Nai
+    replace: Ny
+
+  - find: Leila
+    replace: Lillia
+
+  - find: Asprey
+    replace: Asplay
+
+  - find: Aly
+    replace: Allie
+    notes: It's very important that this one is case-sensitive, since "aly" can appear in the middle of a lot of words.
+
+  - find: Lucie
+    replace: Luzie
+
+  - find: Kumesh
+    replace: Kmetsch
+
+  - find: Kanna
+    replace: Kana
+
+  - find: Harksten
+    replace: Hrqstn
+    notes: Elq's last name
+
+  - find: Astartus
+    replace: Astartos
+    notes: Nygglatho's father, also her last name in SukaMoka v4.
+
+  - find: Valgalis
+    replace: Valgulious
+    notes: Dug Weapons
+
+  - find: Seniolis
+    replace: Seniorious
+    notes: Was misspelled as Seniourious until June 30th 2023. Should be fixed now.
+
+  - find: Pachem
+    replace: Parchem
+
+  - find: Mulusmaurea
+    replace: Mulsum Aurea
+
+  # LOCATIONS/ORGANIZATIONS
+  - find: Regul Aire
+    replace: Regule Aire
+
+  - find: Elpis National Defense Force
+    replace: Elpis Air Defense Force
+
+  - find: Elpis(( Mercantile)|( Trading))? Federation
+    replace: Elpis Collective
+    regex: true
+
+  - find: Collinadiluche
+    replace: Collina di Luce
+
+  - find: Orlandri( General)? Trading Company
+    replace: Orlandry Merchants Alliance
+    regex: true
+
+  - find: Orlandri
+    replace: Orlandry
+
+  - find: Port District
+    replace: port district
+
+  - find: Factory District
+    replace: factory district
+
+  - find: Winged Guard Military
+    replace: Winged Guard
+
+  - find: Guardian Wings Military
+    replace: Winged Guard
+
+  - find: Adventurers’ Guild
+    replace: Adventurers Guild
+
+  - find: Church of Holy Light
+    replace: Church of Exalted Light
+
+  - find: Fistilas
+    replace: Fistirus
+
+  - find: '(?<!Imperial )Capital\b'
+    replace: "capital"
+    regex: true
+    case_mode: sentence_aware
+
+  - find: ((Noble)|(Royal)) Wing(s?) Empire
+    replace: Winged Empire
+    regex: true
+
+  - find: Garmond
+    replace: Garmando
+
+  - find: Flowing Sands Confederation
+    replace: Sands Federation
+
+  # SPECIES
+  - find: Teimerre
+    replace: Timere
+
+  - find: Shiantor
+    replace: Chanteur
+
+  - find: Ayrantro(b|p)os
+    replace: ailuranthrope
+    case_mode: sentence_aware
+    regex: true
+
+  - find: (B|b)eastman
+    replace: semifer
+    case_mode: sentence_aware
+    regex: true
+
+  - find: (B|b)eastmen
+    replace: semifer
+    case_mode: sentence_aware
+    regex: true
+
+  - find: (B|b)eastfolk
+    replace: semifer
+    case_mode: sentence_aware
+    regex: true
+
+  - find: (B|b)eastkind
+    replace: semifer
+    case_mode: sentence_aware
+    regex: true
+
+  - find: Borgle
+    replace: boggard
+    case_mode: sentence_aware
+
+  - find: Markless
+    replace: featureless
+    case_mode: sentence_aware
+
+  - find: markless
+    replace: featureless
+    case_mode: sentence_aware
+
+  - find: Lycanthropos
+    replace: lycanthrope
+    case_mode: sentence_aware
+
+  # - find: (F|f)air(y|(ie))
+  #   replace: faerie
+  #   case_mode: sentence_aware
+  #   manual: true
+  #   regex: true
+  #   notes: Except in phrases like "fairy tale"; should be manually checked.
+
+  - find: '\b[Ff]airies\b(?! tale\b)'
+    replace: "faeries"
+    case_mode: sentence_aware
+    regex: true
+
+  - find: '\b[Ff]airy\b(?! tale\b)'
+    replace: "faerie"
+    case_mode: sentence_aware
+    regex: true
+
+  - find: Emnetwyte(s?)
+    replace: emnetwiht
+    case_mode: sentence_aware
+    regex: true
+
+  - find: Alle\b
+    replace: alle
+    case_mode: sentence_aware
+    regex: true
+
+  - find: Armado
+    replace: armado
+    case_mode: sentence_aware
+
+  - find: Ballman
+    replace: ballman
+    case_mode: sentence_aware
+
+  - find: Ballmen
+    replace: ballmen
+    case_mode: sentence_aware
+
+  - find: Bennu
+    replace: bennu
+    case_mode: sentence_aware
+
+  - find: Dragon
+    replace: dragon
+    case_mode: sentence_aware
+
+  - find: Falcon
+    replace: falconfolk
+    case_mode: sentence_aware
+
+  - find: Golem
+    replace: golem
+    case_mode: sentence_aware
+
+  - find: Imp\b
+    replace: imp
+    regex: true
+    case_mode: sentence_aware
+
+  - find: Imps\b
+    replace: imps
+    regex: true
+    case_mode: sentence_aware
+
+  - find: Leprechaun
+    replace: leprechaun
+    case_mode: sentence_aware
+
+  - find: Spectrals
+    replace: spectrals
+    case_mode: sentence_aware
+
+  - find: Troll
+    replace: troll
+    case_mode: sentence_aware
+
+  - find: Frogger
+    replace: frogger
+    case_mode: sentence_aware
+
+  - find: Scarsalantropos
+    replace: scarsalanthrope
+    case_mode: sentence_aware
+
+  - find: Findantropos
+    replace: findanthrope
+    case_mode: sentence_aware
+    notes: Refers to snake people. Official term will be revealed in SukaMoka Vol 1
+
+  - find: Reptrace
+    replace: lizardfolk
+    case_mode: sentence_aware
+
+  - find: Orc
+    replace: orc
+    case_mode: sentence_aware
+
+  - find: Ogre
+    replace: ogre
+    case_mode: sentence_aware
+
+  - find: Giant
+    replace: giant
+    case_mode: sentence_aware
+
+  - find: Gremian
+    replace: gremian
+    case_mode: sentence_aware
+
+  - find: Stalla
+    replace: stalla
+    case_mode: sentence_aware
+
+  - find: Alogantropos
+    replace: aloganthrope
+    case_mode: sentence_aware
+    notes: I honestly have no idea what this is
+
+  - find: Elf
+    replace: elf
+    case_mode: sentence_aware
+
+  - find: Elves
+    replace: elves
+    case_mode: sentence_aware
+
+  - find: Vampiric
+    replace: vampiric
+    case_mode: sentence_aware
+
+  - find: Legiteimitat
+    replace: Legitimitate
+
+  - find: Tourterelle
+    replace: tourterelle
+    case_mode: sentence_aware
+
+  - find: Haresantrobos
+    replace: rabbitfolk
+    case_mode: sentence_aware
+
+  - find: Kikuroppes
+    replace: cyclopes
+    case_mode: sentence_aware
+
+  - find: Kikuroppe
+    replace: cyclops
+    case_mode: sentence_aware
+    notes: Plural is "cyclopes"
+
+  - find: Titanic
+    replace: titanic
+    case_mode: sentence_aware
+
+  - find: Myrmex
+    replace: myrmex
+    case_mode: sentence_aware
+
+  - find: Cygne
+    replace: cygne
+    case_mode: sentence_aware
+
+  # OTHER
+  - find: Second Enchanted Weapons Technician
+    replace: Second Enchantments Officer
+
+  - find: spell vision
+    replace: Sight
+
+  - find: Venom
+    replace: venenum
+    case_mode: sentence_aware
+
+  - find: '\bKaliyons?\b'
+    replace: "Carillon"
+    regex: true
+
+  - find: Dug Weapon
+    replace: dug weapon
+    case_mode: sentence_aware
+
+  - find: Regal Brave
+    replace: Legal Brave
+    notes: One of the two official transliterations I don't like
+
+  - find: adventurer
+    replace: Adventurer
+    notes: Brave should also be capitalized, but not when used as an adjective.
+
+  - find: \.\.\.[ ]?
+    replace: …
+    manual: true
+    regex: true
+    notes: Three periods (optionally followed by a space) --> one ellipsis character (needs manual checking).
+
+  - find: common language
+    replace: official language
+    case_mode: sentence_aware
+
+  - find: Floating Island
+    replace: floating island
+    case_mode: sentence_aware
+
+  - find: Island
+    replace: island
+    case_mode: sentence_aware
+
+  - find: '\b(\d+)(st|nd|rd|th)( floating)? (i|I)sland\b'
+    replace: 'Island No. \1'
+    regex: true
+
+  - find: " - "
+    replace: —
+    notes: space, hyphen, space -> em dash
+
+  - find: " – "
+    replace: —
+    notes: space, en dash, space -> em dash
+
+  - find: "–"
+    replace: —
+    manual: true # Unlikely use of real en dash
+    notes: en dash -> em dash
+
+  - find: Talisman
+    replace: talisman
+    case_mode: sentence_aware
+
+  - find: '\b[gG]ate\b'
+    replace: "gate"
+    case_mode: sentence_aware
+    regex: true
+    manual: true
+    notes: Yen Press exclusively uses "the gates" or "the gates to the faerie homeland", never "the fairy gates" or similar. Requires manual checking.
+
+  - find: Imperial sage
+    replace: Imperial Sage
+
+  - find: Monstrous
+    replace: monsters
+    case_mode: sentence_aware
+    manual: true

--- a/Volumes/replacements.yaml
+++ b/Volumes/replacements.yaml
@@ -231,19 +231,12 @@ rules:
     replace: lycanthrope
     case_mode: sentence_aware
 
-  # - find: (F|f)air(y|(ie))
-  #   replace: faerie
-  #   case_mode: sentence_aware
-  #   manual: true
-  #   regex: true
-  #   notes: Except in phrases like "fairy tale"; should be manually checked.
-
-  - find: '\b[Ff]airies\b(?! tale\b)'
+  - find: '\b[Ff]airies\b(?! [Tt]ale\b)'
     replace: "faeries"
     case_mode: sentence_aware
     regex: true
 
-  - find: '\b[Ff]airy\b(?! tale\b)'
+  - find: '\b[Ff]airy\b(?! [Tt]ale\b)'
     replace: "faerie"
     case_mode: sentence_aware
     regex: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pylatexenc
 regex
 pint
 black
+pyyaml


### PR DESCRIPTION
This adds a script `Scripts/regex_replace.py` that takes in markdown files, or a directory of markdown files, and a YAML replacement file to make the replacements.

Standard usage is like so:
```
❯ python Scripts/regex_replace.py Volumes/Volume_04/Text/3.4.md Volumes/replacements.yaml --in-place
Processed 1 file(s).
Manual review file: manual_review.md
Manual-review hits: 0
```

For all replacements marked as manual, it creates a `manual_review.md` file with the changes:

```
# Manual Review Report

## File: `Volumes/Volume_04/Text/3.4.md`

### Rule 110
- find: `\b[gG]ate\b`
- replace: `gate`
- notes: Yen Press exclusively uses "the gates" or "the gates to the faerie homeland", never "the fairy gates" or similar. Requires manual checking.

- location: `Volumes/Volume_04/Text/3.4.md:47:1`
  - matched: `Gate`
  - context: ` attitude? You won’t listen to me, your senior?”\n\nGate. The gate is Gated.\n\n“No matter who it’s against,`

- location: `Volumes/Volume_04/Text/3.4.md:47:11`
  - matched: `gate`
  - context: ` You won’t listen to me, your senior?”\n\nGate. The gate is Gated.\n\n“No matter who it’s against, there are`
```

I've converted our spreadsheet into a YAML file in `Volumes/replacements.yaml`, and tried to simplify some of them and get rid of some of the manual ones now that we can use more powerful regular expressions. There's 3 case modes: `literal`, `preserve_case`, and `sentence_aware`. The one that is more important is `sentence_aware`, which is useful for the ones we want to lowercase, except for if it starts the sentence. (Note that `sentence_aware` shouldn't be used when the replacement is already capitalized, since then that would make it lowercase if it doesn't begin the sentence.) 

The replacements YAML may need some checking to make sure they work as intended. Especially with plurals and whatnot.

I tested it on some of the manual ones:

**Before**:
The fairies went over here. The Fairies went over here. The fairies went to the fairy house, where they listened to a Fairy tale or a fairy tale or a Fairy Tale about some fairy. Fairies are stup. The Imperial Capital is here, but it is the Capital. But you should not Capitalize the capital of the Capital, or the Imperial Capital. This Armado... Amardo do be Amardo. armado.

**After**:
The faeries went over here. The faeries went over here. The faeries went to the faerie house, where they listened to a Fairy tale or a fairy tale or a Fairy Tale about some faerie. Faeries are stup. The Imperial Capital is here, but it is the capital. But you should not Capitalize the capital of the capital, or the Imperial Capital. This armado…Amardo do be Amardo. armado.

Note the last "armado" is lowercase because it was not matched in the case-sensitive matching. You can make the matching case insensitive with the regex flags (more info in the replacements YAML), or just change the regex itself.